### PR TITLE
Enable active var on the accordion item template

### DIFF
--- a/dist/js/foundation-apps.js
+++ b/dist/js/foundation-apps.js
@@ -1016,7 +1016,8 @@
         templateUrl: 'components/accordion/accordion-item.html',
         transclude: true,
         scope: {
-          title: '@'
+          title: '@',
+          active: '@'
         },
         require: '^zfAccordion',
         replace: true,


### PR DESCRIPTION
Add the 'active' variable on the accordion item scope to be able to use the 'active' variable on  the angular accordion item template
This is used to reopen the opened accordion after reload the page (using angular controller)